### PR TITLE
Don't require future

### DIFF
--- a/sparse_list.py
+++ b/sparse_list.py
@@ -12,7 +12,11 @@ wish to store these. cf. Sparse array:
     http://en.wikipedia.org/wiki/Sparse_array
 '''
 
-from future.builtins import range
+try:
+    from future.builtins import range
+except ImportError:
+    # If they don't have future, then allow xrange.
+    range = xrange
 from six import iteritems, itervalues
 from six.moves import zip_longest
 


### PR DESCRIPTION
Future is a big library. sparse_list only needs it for one little function. If it isn't installed, then just default to xrange which does what we want.