### PR TITLE
Update __delitem__ implementation

### DIFF
--- a/sparse_list.py
+++ b/sparse_list.py
@@ -13,10 +13,11 @@ wish to store these. cf. Sparse array:
 '''
 
 try:
-    from future.builtins import range
-except ImportError:
-    # If they don't have future, then allow xrange.
-    range = xrange
+    xrange
+except NameError:
+    # On Python 3, range() is equivalent to Python 2's xrange()
+    xrange = range
+
 from six import iteritems, itervalues
 from six.moves import zip_longest
 
@@ -47,24 +48,22 @@ class SparseList(object):
     def __getitem__(self, index):
         try:
             s = slice(index.start, index.stop, index.step).indices(self.size)
-            return [self[i] for i in range(*s)]
+            return [self[i] for i in xrange(*s)]
         except AttributeError:
             i = slice(index).indices(self.size)[1]
             return self.elements.get(i, self.default)
 
     def __delitem__(self, item):
-        try:
-            del self.elements[item]
-        except TypeError:
-            s = slice(item.start, item.stop, item.step).indices(self.size)
-            for i in range(*s):
-                del self.elements[i]
-        except KeyError:
-            pass
+        if isinstance(item, slice):
+            indices = xrange(*item.indices(self.size))
+        else:
+            indices = (item, )
 
-    def __delslice__(self, start, stop):
-        for index in range(start, stop):
-            self.__delitem__(index)
+        for i in indices:
+            try:
+                del self.elements[i]
+            except KeyError:
+                pass
 
     def __iter__(self):
         for index in range(self.size):

--- a/t_sparse_list.py
+++ b/t_sparse_list.py
@@ -13,138 +13,139 @@ except NameError:
 class TestSparseList(unittest.TestCase):
     def test_init_zero(self):
         sl = sparse_list.SparseList(0)
-        self.assertEquals(0, len(sl))
+        self.assertEqual(0, len(sl))
 
     def test_init_non_zero(self):
         sl = sparse_list.SparseList(10)
-        self.assertEquals(10, len(sl))
+        self.assertEqual(10, len(sl))
 
     def test_init_no_default(self):
         sl = sparse_list.SparseList(1)
-        self.assertEquals(None, sl.default)
+        self.assertEqual(None, sl.default)
 
     def test_init_default(self):
         sl = sparse_list.SparseList(1, 'test')
-        self.assertEquals('test', sl.default)
+        self.assertEqual('test', sl.default)
 
     def test_random_access_write(self):
         sl = sparse_list.SparseList(1)
         sl[0] = 'alice'
-        self.assertEquals({0: 'alice'}, sl.elements)
+        self.assertEqual({0: 'alice'}, sl.elements)
 
     def test_random_access_read_present(self):
         sl = sparse_list.SparseList(2)
         sl[0] = 'brent'
-        self.assertEquals('brent', sl[0])
+        self.assertEqual('brent', sl[0])
 
     def test_random_access_read_absent(self):
         sl = sparse_list.SparseList(2, 'absent')
         sl[1] = 'clint'
-        self.assertEquals('absent', sl[0])
+        self.assertEqual('absent', sl[0])
 
     def test_iteration_empty(self):
         sl = sparse_list.SparseList(3)
-        self.assertEquals([None, None, None], list(sl))
+        self.assertEqual([None, None, None], list(sl))
 
     def test_iteration_populated(self):
         sl = sparse_list.SparseList(5)
         sl[1], sl[3] = 'a', 'b'
-        self.assertEquals([None, 'a', None, 'b', None], list(sl))
+        self.assertEqual([None, 'a', None, 'b', None], list(sl))
 
     def test_membership_absent(self):
         sl = sparse_list.SparseList(5)
         sl[2], sl[3], = 1, 2
-        self.assertEquals(False, 3 in sl)
+        self.assertEqual(False, 3 in sl)
 
     def test_membership_present(self):
         sl = sparse_list.SparseList(5)
         sl[2], sl[3], = 1, 2
-        self.assertEquals(True, 2 in sl)
+        self.assertEqual(True, 2 in sl)
 
     def test_string_representations(self):
         sl = sparse_list.SparseList(5, 0)
         sl[3], sl[4] = 5, 6
-        self.assertEquals('[0, 0, 0, 5, 6]', repr(sl))
-        self.assertEquals('[0, 0, 0, 5, 6]', str(sl))
+        self.assertEqual('[0, 0, 0, 5, 6]', repr(sl))
+        self.assertEqual('[0, 0, 0, 5, 6]', str(sl))
 
     def test_initialisation_by_dict(self):
         sl = sparse_list.SparseList({
             4: 6,
             3: 5,
         }, 0)
-        self.assertEquals([0, 0, 0, 5, 6], sl)
+        self.assertEqual([0, 0, 0, 5, 6], sl)
 
     def test_initialisation_by_dict_with_non_numeric_key(self):
         self.assertRaises(ValueError, sparse_list.SparseList, {'a': 5})
 
     def test_initialisation_by_list(self):
         sl = sparse_list.SparseList([0, 1, 2, 4])
-        self.assertEquals([0, 1, 2, 4], sl)
+        self.assertEqual([0, 1, 2, 4], sl)
 
     def test_initialisation_by_generator(self):
         gen = (x for x in (1, 2, 3))
         sl = sparse_list.SparseList(gen)
-        self.assertEquals([1, 2, 3], sl)
+        self.assertEqual([1, 2, 3], sl)
 
     def test_access_with_negative_index(self):
         sl = sparse_list.SparseList([0, 1, 2, 4])
-        self.assertEquals(4, sl[-1])
+        self.assertEqual(4, sl[-1])
 
     def test_access_with_negative_index_with_no_value(self):
         sl = sparse_list.SparseList(5, 0)
-        self.assertEquals(0, sl[-1])
+        self.assertEqual(0, sl[-1])
 
     def test_slice(self):
         sl = sparse_list.SparseList([0, 1, 2, 4], 10)
-        self.assertEquals([1, 2], sl[1:3])
+        self.assertEqual([1, 2], sl[1:3])
 
     def test_extended_slice(self):
         sl = sparse_list.SparseList([0, 1, 2, 3, 4, 5, 6, ])
-        self.assertEquals([1, 3, 5], sl[1:6:2])
+        self.assertEqual([1, 3, 5], sl[1:6:2])
 
     def test_extended_slice_with_negative_stop(self):
         sl = sparse_list.SparseList([0, 1, 2, 3, 4, 5, 6, ])
-        self.assertEquals([1, 3, 5], sl[1:-1:2])
+        self.assertEqual([1, 3, 5], sl[1:-1:2])
 
     def test_slice_reversal_full(self):
         sl = sparse_list.SparseList([1, 2, 3])
-        self.assertEquals([3, 2, 1], sl[::-1])
+        self.assertEqual([3, 2, 1], sl[::-1])
 
     def test_slice_reversal_empty(self):
         sl = sparse_list.SparseList(4)
-        self.assertEquals([None, None, None, None], sl[::-1])
+        self.assertEqual([None, None, None, None], sl[::-1])
 
     def test_reversed(self):
         sl = sparse_list.SparseList([1, 2, 3])
-        self.assertEquals([3, 2, 1], list(reversed(sl)))
+        self.assertEqual([3, 2, 1], list(reversed(sl)))
 
     def test_sorted(self):
         sl = sparse_list.SparseList({0: 1, 4: 1}, 0)
-        self.assertEquals([0, 0, 0, 1, 1], list(sorted(sl)))
+        self.assertEqual([0, 0, 0, 1, 1], list(sorted(sl)))
 
     def test_get_out_of_bounds(self):
         sl = sparse_list.SparseList(1)
-        self.assertEquals(None, sl[1])
+        self.assertEqual(None, sl[1])
 
     def test_set_out_of_bounds(self):
         sl = sparse_list.SparseList(1)
         sl[100] = 1
-        self.assertEquals(101, len(sl))
+        self.assertEqual(101, len(sl))
 
     def test_present_item_removal(self):
         sl = sparse_list.SparseList({0: 1, 4: 1}, 0)
         del sl[0]
-        self.assertEquals([0, 0, 0, 0, 1], sl)
+        self.assertEqual([0, 0, 0, 0, 1], sl)
 
     def test_missing_item_removal(self):
         sl = sparse_list.SparseList({0: 1, 4: 1}, 0)
         del sl[1]
-        self.assertEquals([1, 0, 0, 0, 1], sl)
+        self.assertEqual([1, 0, 0, 0, 1], sl)
 
     def test_slice_removal(self):
         sl = sparse_list.SparseList(range(10), None)
         del sl[3:5]
-        self.assertEquals([0, 1, 2, None, None, 5, 6, 7, 8, 9], sl)
+        self.assertEqual([0, 1, 2, None, None, 5, 6, 7, 8, 9], sl)
+
     def test_unbounded_head_slice_removal(self):
         sl = sparse_list.SparseList(range(10), None)
         del sl[:3]
@@ -158,39 +159,39 @@ class TestSparseList(unittest.TestCase):
     def test_append(self):
         sl = sparse_list.SparseList(1, 0)
         sl.append(1)
-        self.assertEquals([0, 1], sl)
+        self.assertEqual([0, 1], sl)
 
     def test_clone(self):
         a = sparse_list.SparseList([1, 2, 3])
         b = a[:]
         b.append(4)
-        self.assertEquals([1, 2, 3], a)
-        self.assertEquals([1, 2, 3, 4], b)
+        self.assertEqual([1, 2, 3], a)
+        self.assertEqual([1, 2, 3, 4], b)
 
     def test_concatenation(self):
         a = sparse_list.SparseList([1, 2, 3])
         b = sparse_list.SparseList([4, 5, 6])
         c = a + b
-        self.assertEquals([1, 2, 3], a)
-        self.assertEquals([4, 5, 6], b)
-        self.assertEquals([1, 2, 3, 4, 5, 6], c)
+        self.assertEqual([1, 2, 3], a)
+        self.assertEqual([4, 5, 6], b)
+        self.assertEqual([1, 2, 3, 4, 5, 6], c)
 
     def test_in_place_concatenation(self):
         a = sparse_list.SparseList([1, 2, 3])
         b = sparse_list.SparseList([4, 5, 6])
         a += b
-        self.assertEquals([1, 2, 3, 4, 5, 6], a)
-        self.assertEquals([4, 5, 6], b)
+        self.assertEqual([1, 2, 3, 4, 5, 6], a)
+        self.assertEqual([4, 5, 6], b)
 
     def test_equality(self):
         a = sparse_list.SparseList([1, 2, 3])
         b = sparse_list.SparseList([1, 2, 3])
         self.assertTrue(a == b)
         self.assertTrue(not a != b)
-        self.assertEquals(a, b)
+        self.assertEqual(a, b)
         self.assertTrue(b == a)
         self.assertTrue(not b != a)
-        self.assertEquals(b, a)
+        self.assertEqual(b, a)
 
     def test_inequality_same_length(self):
         a = sparse_list.SparseList([1, 2, 3])
@@ -231,38 +232,38 @@ class TestSparseList(unittest.TestCase):
     def test_multiply(self):
         sl = sparse_list.SparseList({0: 1, 4: 1}, 0)
         sl4 = sl * 4
-        self.assertEquals([1, 0, 0, 0, 1], sl)
-        self.assertEquals(
+        self.assertEqual([1, 0, 0, 0, 1], sl)
+        self.assertEqual(
             [1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1], sl4)
-        self.assertEquals(len(sl) * 4, len(sl4))
+        self.assertEqual(len(sl) * 4, len(sl4))
 
     def test_multiply_in_place(self):
         sl = sparse_list.SparseList({0: 1, 4: 1}, 0)
         sl *= 4
-        self.assertEquals(
+        self.assertEqual(
             [1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1], sl)
 
     def test_count_value(self):
         sl = sparse_list.SparseList({0: 1, 4: 1}, 0)
-        self.assertEquals(2, sl.count(1))
+        self.assertEqual(2, sl.count(1))
 
     def test_count_default_value(self):
         sl = sparse_list.SparseList(100, 1)
         sl[5] = 1
-        self.assertEquals(100, sl.count(1))
+        self.assertEqual(100, sl.count(1))
 
     def test_extend(self):
         sl = sparse_list.SparseList([1, 2, 3])
         sl.extend((4, 5, 6))
-        self.assertEquals([1, 2, 3, 4, 5, 6], sl)
+        self.assertEqual([1, 2, 3, 4, 5, 6], sl)
 
     def test_index_value(self):
         sl = sparse_list.SparseList({0: 1, 4: 1}, 0)
-        self.assertEquals(0, sl.index(1))
+        self.assertEqual(0, sl.index(1))
 
     def test_index_default_value(self):
         sl = sparse_list.SparseList({0: 1, 4: 1}, 0)
-        self.assertEquals(1, sl.index(0))
+        self.assertEqual(1, sl.index(0))
 
     def test_index_absent_default_value(self):
         sl = sparse_list.SparseList([1, 2, 3], 0)
@@ -274,7 +275,7 @@ class TestSparseList(unittest.TestCase):
 
     def test_pop_no_value(self):
         sl = sparse_list.SparseList(4)
-        self.assertEquals(None, sl.pop())
+        self.assertEqual(None, sl.pop())
 
     def test_pop_empty(self):
         sl = sparse_list.SparseList(0)
@@ -283,27 +284,27 @@ class TestSparseList(unittest.TestCase):
     def test_pop_value(self):
         sl = sparse_list.SparseList([1, 2, 3])
         popped = sl.pop()
-        self.assertEquals(3, popped)
-        self.assertEquals(2, len(sl))
-        self.assertEquals([1, 2], sl)
+        self.assertEqual(3, popped)
+        self.assertEqual(2, len(sl))
+        self.assertEqual([1, 2], sl)
 
     def test_push_value(self):
         sl = sparse_list.SparseList([1, 2, 3])
         sl.push(4)
-        self.assertEquals(4, len(sl))
-        self.assertEquals([1, 2, 3, 4], sl)
+        self.assertEqual(4, len(sl))
+        self.assertEqual([1, 2, 3, 4], sl)
 
     def test_remove_value(self):
         sl = sparse_list.SparseList([1, 2, 3])
         sl.remove(2)
-        self.assertEquals(3, len(sl))
-        self.assertEquals([1, None, 3], sl)
+        self.assertEqual(3, len(sl))
+        self.assertEqual([1, None, 3], sl)
 
     def test_remove_only_first_value(self):
         sl = sparse_list.SparseList([2, 2, 3])
         sl.remove(2)
-        self.assertEquals(3, len(sl))
-        self.assertEquals([None, 2, 3], sl)
+        self.assertEqual(3, len(sl))
+        self.assertEqual([None, 2, 3], sl)
 
     def test_remove_non_value(self):
         sl = sparse_list.SparseList([1, 2, 3])
@@ -312,7 +313,7 @@ class TestSparseList(unittest.TestCase):
     def test_remove_default_value_does_nothing(self):
         sl = sparse_list.SparseList(4, None)
         sl.remove(None)
-        self.assertEquals([None, None, None, None], sl)
+        self.assertEqual([None, None, None, None], sl)
 
 if __name__ == '__main__':
     unittest.main()

--- a/t_sparse_list.py
+++ b/t_sparse_list.py
@@ -2,7 +2,12 @@
 
 import unittest
 import sparse_list
-from future.builtins import range
+
+try:
+    xrange
+except NameError:
+    # On Python 3, range() is equivalent to Python 2's xrange()
+    xrange = range
 
 
 class TestSparseList(unittest.TestCase):
@@ -140,6 +145,15 @@ class TestSparseList(unittest.TestCase):
         sl = sparse_list.SparseList(range(10), None)
         del sl[3:5]
         self.assertEquals([0, 1, 2, None, None, 5, 6, 7, 8, 9], sl)
+    def test_unbounded_head_slice_removal(self):
+        sl = sparse_list.SparseList(range(10), None)
+        del sl[:3]
+        self.assertEqual([None, None, None, 3, 4, 5, 6, 7, 8, 9], sl)
+
+    def test_unbounded_tail_slice_removal(self):
+        sl = sparse_list.SparseList(range(10), None)
+        del sl[5:]
+        self.assertEqual([0, 1, 2, 3, 4, None, None, None, None, None], sl)
 
     def test_append(self):
         sl = sparse_list.SparseList(1, 0)


### PR DESCRIPTION
This updates `__delitem__` as discussed in #5:

* Update `__delitem__` to handle slices
* Remove `__delslice__` which is deprecated on Python 2, where the runtime will create a slice instance and pass it to `__delitem__` if `__delslice__` does not exist.
* Use `xrange` instead of `range` to avoid running out of memory on Python 2 when passed a slice like `[1:]` which will allocate `sys.maxint - 1` elements
* Update the test code to use the same check as the main sparse_list