### PR TITLE
Fix slice assignment

### DIFF
--- a/sparse_list.py
+++ b/sparse_list.py
@@ -44,7 +44,7 @@ class SparseList(object):
     def __setitem__(self, index, value):
         try:
             if index.start:
-                self.size = index.start + len(value)
+                self.size = max(self.size, index.start + len(value))
             s = slice(index.start, index.stop, index.step).indices(self.size)
             for v, i in enumerate(xrange(*s)):
                 self.__setitem__(i, value[v])

--- a/test_sparse_list.py
+++ b/test_sparse_list.py
@@ -114,6 +114,13 @@ class TestSparseList(unittest.TestCase):
         sl = sparse_list.SparseList(4)
         self.assertEqual([None, None, None, None], sl[::-1])
 
+    def test_slice_list_size(self):
+        initial_size = 20
+        sl = sparse_list.SparseList(initial_size)
+        sample_tuple = (1, 2, 3, 4)
+        sl[2:2+len(sample_tuple)] = sample_tuple
+        self.assertEqual(len(sl), initial_size)
+
     def test_reversed(self):
         sl = sparse_list.SparseList([1, 2, 3])
         self.assertEqual([3, 2, 1], list(reversed(sl)))


### PR DESCRIPTION
It seems like this got broken here: https://github.com/johnsyweb/python_sparse_list/commit/d3a95a5336206cdb151c78b141f820b6efa6a149#diff-00b84eb5c4916378a371c88b861efc62L64

1) This is how python's list behaves:
```
>>> l = [None,]*20
>>> l
[None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]
>>> l[1:4] = [1,2,3]
>>> l
[None, 1, 2, 3, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]
>>> len(l)
20
>>>
```
2) This is how sparseList currently behaves (bug):
```
>>> s = SparseList(20)
>>> s
[None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]
>>> s[1:4] = [1,2,3]
>>> s
[None, 1, 2, 3]
>>> len(s)
4
>>> s.size
4
>>>
```
3) This is how my fixed version of sparseList behaves:
```
>>> s = SparseList(20)
>>> s
[None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]
>>> s[1:4] = [1,2,3]
>>> s
[None, 1, 2, 3, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]
>>> len(s)
20
```

Thanks.