### PR TITLE
Fix deletion of empty slices, closes #16

### DIFF
--- a/sparse_list.py
+++ b/sparse_list.py
@@ -79,6 +79,9 @@ class SparseList(object):
         else:
             indices = (item, )
 
+        if not indices:
+            return
+
         offset = 0
 
         for k in sorted(self.elements.keys()):

--- a/test_sparse_list.py
+++ b/test_sparse_list.py
@@ -176,6 +176,11 @@ class TestSparseList(unittest.TestCase):
         del sl[::2]
         self.assertEqual([1, 3, 5], sl)
 
+    def test_empty_removal(self):
+        sl = sparse_list.SparseList(xrange(5), None)
+        del sl[3:3]
+        self.assertEqual([0, 1, 2, 3, 4], sl)
+
     def test_append(self):
         sl = sparse_list.SparseList(1, 0)
         sl.append(1)


### PR DESCRIPTION
Removing an empty slice should not fail with an `IndexError`, see #16.