### PR TITLE
Read The Docs?

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
     - name: Checkout

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - name: Checkout

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#   - requirements: docs/requirements.txt

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-python 3.9.0
+python 3.11.4

--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,8 @@ Thanks
 If you find this stuff useful, please follow this repository on
 `GitHub <https://github.com/johnsyweb/python_sparse_list>`__. If you
 have something to say, you can contact
-`johnsyweb <http://johnsy.com/about/>`__ on
-`Twitter <http://twitter.com/johnsyweb/>`__ and
+`johnsyweb <https://johnsy.com/about/>`__ on
+`Mastodon <https://mastodon.world/@johnsyweb>`__ and
 `GitHub <https://github.com/johnsyweb/>`__.
 
 
@@ -56,7 +56,7 @@ Many thanks
 -----------
 
 I'm grateful for contributions to what was a solo project (hooray for
-`GitHub :octocat:) <http://github.com/>`__! If you'd like to thank the
+`GitHub :octocat:) <https://github.com/>`__! If you'd like to thank the
 contributors, you can find their details here:
 
 https://github.com/johnsyweb/python_sparse_list/graphs/contributors


### PR DESCRIPTION
# Context

https://blog.readthedocs.com/migrate-configuration-v2/

# Change

- Replaces EOL Pythons with Current ones
- Adds minimum viable .readthedocs.yaml

# Considerations

I wonder whether it's time to archive this.